### PR TITLE
Fix distribution utility package installations (add to system installs & loosen constraints)

### DIFF
--- a/1.18-alpine/Dockerfile
+++ b/1.18-alpine/Dockerfile
@@ -25,7 +25,8 @@ ENV aws_region_name=""
 RUN apk update && apk add \
     bash \
     openssl \
-    python3
+    python3 \
+    py3-six
 
 # Copy python dependencies list
 COPY ./requirements.txt ./requirements.txt

--- a/1.18-alpine/requirements.txt
+++ b/1.18-alpine/requirements.txt
@@ -18,7 +18,7 @@ requests==2.32.2
 requests-file==2.0.0
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 tldextract==5.1.2
 tqdm==4.66.4
 urllib3==1.26.18

--- a/1.19-alpine/Dockerfile
+++ b/1.19-alpine/Dockerfile
@@ -26,7 +26,10 @@ RUN apk update && apk add \
     bash \
     openssl \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-distlib \
+    py3-packaging \
+    py3-six
 
 # Copy python dependencies list
 COPY ./requirements.txt ./requirements.txt

--- a/1.19-alpine/requirements.txt
+++ b/1.19-alpine/requirements.txt
@@ -7,7 +7,7 @@ chardet==4.0.0
 colorama==0.4.4
 contextlib2==0.6.0
 dirutility==0.7.20
-distlib==0.3.1
+distlib>=0.3.1
 distro==1.9.0
 docutils==0.16
 filelock==3.14.0
@@ -18,7 +18,7 @@ lockfile==0.12.2
 looptools==1.2.4
 msgpack==1.0.2
 ordered-set==4.0.2
-packaging==20.9
+packaging>=20.9
 pep517==0.9.1
 progress==1.5
 pyasn1==0.6.0
@@ -32,8 +32,7 @@ requests-file==2.0.0
 retrying==1.3.3
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.15.0; python_version <= "3.9"
-six==1.16.0; python_version >= "3.10"
+six>=1.15.0
 tldextract==5.1.2
 toml==0.10.2
 tqdm==4.66.4

--- a/1.20-alpine/Dockerfile
+++ b/1.20-alpine/Dockerfile
@@ -26,7 +26,10 @@ RUN apk update && apk add \
     bash \
     openssl \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-distlib \
+    py3-packaging \
+    py3-six
 
 # Copy python dependencies list
 COPY ./requirements.txt ./requirements.txt

--- a/1.20-alpine/requirements.txt
+++ b/1.20-alpine/requirements.txt
@@ -8,7 +8,7 @@ chardet==4.0.0
 colorama==0.4.4
 contextlib2==0.6.0
 dirutility==0.7.20
-distlib==0.3.1
+distlib>=0.3.1
 distro==1.9.0
 docutils==0.16
 filelock==3.14.0
@@ -19,7 +19,7 @@ lockfile==0.12.2
 looptools==1.2.4
 msgpack==1.0.2
 ordered-set==4.0.2
-packaging==20.9
+packaging>=20.9
 pep517==0.10.0
 progress==1.5
 pyasn1==0.6.0
@@ -32,8 +32,7 @@ requests-file==2.0.0
 retrying==1.3.3
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.15.0; python_version <= "3.9"
-six==1.16.0; python_version >= "3.10"
+six>=1.15.0
 tldextract==5.1.2
 toml==0.10.2
 tqdm==4.66.4

--- a/1.21-alpine/Dockerfile
+++ b/1.21-alpine/Dockerfile
@@ -26,7 +26,10 @@ RUN apk update && apk add \
     bash \
     openssl \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-distlib \
+    py3-packaging \
+    py3-six
 
 # Copy python dependencies list
 COPY ./requirements.txt ./requirements.txt

--- a/1.21-alpine/requirements.txt
+++ b/1.21-alpine/requirements.txt
@@ -8,7 +8,7 @@ charset-normalizer==3.3.2
 colorama==0.4.4
 contextlib2==21.6.0
 dirutility==0.7.20
-distlib==0.3.3
+distlib>=0.3.3
 distro==1.9.0
 docutils==0.16
 filelock==3.14.0
@@ -19,7 +19,7 @@ lockfile==0.12.2
 looptools==1.2.4
 msgpack==1.0.2
 ordered-set==4.0.2
-packaging==20.9
+packaging>=20.9
 pep517==0.12.0
 progress==1.6
 pyasn1==0.6.0
@@ -32,7 +32,7 @@ requests-file==2.0.0
 retrying==1.3.3
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 tldextract==5.1.2
 toml==0.10.2
 tomli==2.0.1

--- a/1.22-alpine/Dockerfile
+++ b/1.22-alpine/Dockerfile
@@ -26,7 +26,9 @@ RUN apk update && apk add \
     bash \
     openssl \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-packaging \
+    py3-six
 
 # Copy python dependencies list
 COPY ./requirements.txt ./requirements.txt

--- a/1.22-alpine/requirements.txt
+++ b/1.22-alpine/requirements.txt
@@ -10,7 +10,7 @@ filelock==3.14.0
 idna==3.7
 jmespath==1.0.1
 looptools==1.2.4
-packaging==21.3
+packaging>=21.3
 pyasn1==0.6.0
 pyparsing==3.0.9
 python-dateutil==2.9.0.post0
@@ -21,7 +21,7 @@ requests-file==2.0.0
 retrying==1.3.3
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 tldextract==5.1.2
 tqdm==4.66.4
 urllib3==2.2.1

--- a/1.23-alpine/Dockerfile
+++ b/1.23-alpine/Dockerfile
@@ -26,7 +26,9 @@ RUN apk update && apk add \
     bash \
     openssl \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-packaging \
+    py3-six
 
 # Copy python dependencies list
 COPY ./requirements.txt ./requirements.txt

--- a/1.23-alpine/requirements.txt
+++ b/1.23-alpine/requirements.txt
@@ -10,7 +10,7 @@ filelock==3.14.0
 idna==3.7
 jmespath==1.0.1
 looptools==1.2.4
-packaging==21.3
+packaging>=21.3
 pyasn1==0.6.0
 pyparsing==3.0.9
 python-dateutil==2.9.0.post0
@@ -21,7 +21,7 @@ requests-file==2.0.0
 retrying==1.3.3
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 tldextract==5.1.2
 tqdm==4.66.4
 urllib3==2.2.1

--- a/1.24-alpine/Dockerfile
+++ b/1.24-alpine/Dockerfile
@@ -26,7 +26,9 @@ RUN apk update && apk add \
     bash \
     openssl \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-packaging \
+    py3-six
 
 # Copy python dependencies list
 COPY ./requirements.txt ./requirements.txt

--- a/1.24-alpine/requirements.txt
+++ b/1.24-alpine/requirements.txt
@@ -10,7 +10,7 @@ filelock==3.14.0
 idna==3.7
 jmespath==1.0.1
 looptools==1.2.4
-packaging==21.3
+packaging>=21.3
 pyasn1==0.6.0
 pyparsing==3.0.9
 python-dateutil==2.9.0.post0
@@ -21,7 +21,7 @@ requests-file==2.0.0
 retrying==1.3.3
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 tldextract==5.1.2
 tqdm==4.66.4
 urllib3==2.2.1

--- a/1.25-alpine/Dockerfile
+++ b/1.25-alpine/Dockerfile
@@ -26,7 +26,9 @@ RUN apk update && apk add \
     bash \
     openssl \
     python3 \
-    py3-pip
+    py3-pip \
+    py3-packaging \
+    py3-six
 
 # Copy python dependencies list
 COPY ./requirements.txt ./requirements.txt

--- a/1.25-alpine/requirements.txt
+++ b/1.25-alpine/requirements.txt
@@ -10,7 +10,7 @@ filelock==3.14.0
 idna==3.7
 jmespath==1.0.1
 looptools==1.2.4
-packaging==23.2
+packaging>=23.2
 pyasn1==0.6.0
 pyparsing==3.1.1
 python-dateutil==2.9.0.post0
@@ -20,7 +20,7 @@ requests==2.32.2
 requests-file==2.0.0
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 tldextract==5.1.2
 tqdm==4.66.4
 urllib3==2.2.1


### PR DESCRIPTION
- add distribution utility (disutils) package installations to the system package install step of the Dockerfiles to ensure latest version available from the Alpine OS is installed
- loosen disutil package constraints in requirements.txt