### PR TITLE
'six' Python package installation

### DIFF
--- a/1.17-alpine-v10/Dockerfile
+++ b/1.17-alpine-v10/Dockerfile
@@ -25,7 +25,8 @@ ENV aws_region_name=""
 RUN apk update && apk add \
     bash \
     openssl \
-    python3
+    python3 \
+    py3-six
 
 # Install Python dependencies
 COPY ["requirements-base.txt", "requirements.txt", "./"]

--- a/1.17-alpine-v10/requirements.txt
+++ b/1.17-alpine-v10/requirements.txt
@@ -16,7 +16,7 @@ requests==2.32.2
 requests-file==2.1.0
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 tldextract==5.1.2
 tqdm==4.66.4
 urllib3==1.26.18; python_version < "3.10"

--- a/1.17-alpine-v11/Dockerfile
+++ b/1.17-alpine-v11/Dockerfile
@@ -25,7 +25,8 @@ ENV aws_region_name=""
 RUN apk update && apk add \
     bash \
     openssl \
-    python3
+    python3 \
+    py3-six
 
 # Install Python dependencies
 COPY ["requirements-base.txt", "requirements.txt", "./"]

--- a/1.17-alpine-v11/requirements.txt
+++ b/1.17-alpine-v11/requirements.txt
@@ -16,7 +16,7 @@ requests==2.32.2
 requests-file==2.1.0
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 tldextract==5.1.2
 tqdm==4.66.4
 urllib3==1.26.18; python_version < "3.10"

--- a/1.17-alpine-v8/Dockerfile
+++ b/1.17-alpine-v8/Dockerfile
@@ -37,7 +37,8 @@ COPY --from=base /etc/nginx/ /etc/nginx/
 RUN apk update && apk add \
     bash \
     openssl \
-    python3
+    python3 \
+    py3-six
 
 # Install Python dependencies
 COPY ["requirements-base.txt", "requirements.txt", "./"]

--- a/1.17-alpine-v8/requirements.txt
+++ b/1.17-alpine-v8/requirements.txt
@@ -16,7 +16,7 @@ requests==2.32.2
 requests-file==2.1.0
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 tldextract==5.1.2
 tqdm==4.66.4
 urllib3==1.26.18; python_version < "3.10"

--- a/1.17-alpine-v9/Dockerfile
+++ b/1.17-alpine-v9/Dockerfile
@@ -25,7 +25,8 @@ ENV aws_region_name=""
 RUN apk update && apk add \
     bash \
     openssl \
-    python3
+    python3 \
+    py3-six
 
 # Install Python dependencies
 COPY ["requirements-base.txt", "requirements.txt", "./"]

--- a/1.17-alpine-v9/requirements.txt
+++ b/1.17-alpine-v9/requirements.txt
@@ -16,7 +16,7 @@ requests==2.32.2
 requests-file==2.1.0
 rsa==4.7.2
 s3transfer==0.10.1
-six==1.16.0
+six>=1.16.0
 tldextract==5.1.2
 tqdm==4.66.4
 urllib3==1.26.18; python_version < "3.10"


### PR DESCRIPTION
- add installation of Python 'six' package to Dockerfile system package installations
- fix 'six' version constaints in requirements.txt to allow for system packages to install the latest version